### PR TITLE
Improvements to the PKGBUILD + Rely on a git commit hash rather than being a VCS package

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,17 +1,14 @@
-# Maintainer:  echo -n 'TWF0dCBDLiA8bWF0dEBnZXRjcnlzdC5hbD4=' | base64 -d
-# Contributor: echo -n 'RHlsYW4gQXJhcHMgPGR5bEB0Znduby5nZj4=' | base64 -d
+# Maintainer:  echo -n 'TWF0dCBDLiA8bWF0dEBnZXRjcnlzdC5hbD4='     | base64 -d
+# Contributor: echo -n 'TWljaGFsIFMuIDxtaWNoYWxAZ2V0Y3J5c3QuYWw+' | base64 -d
+# Contributor: echo -n 'Um9iaW4gQy4gPHJjYW5kYXVAZ2V0Y3J5c3QuYWw+' | base64 -d
 
 pkgname=neofetch
-_pkgname=neofetch
-pkgver=8.0
-pkgrel=69
+pkgver=429499e9b9b39127a8a781d135cafb6babdea631
+pkgrel=1
 pkgdesc="A CLI system information tool written in BASH that supports displaying images."
 arch=('any')
-url="https://github.com/dylanaraps/${_pkgname}"
+url="https://github.com/dylanaraps/neofetch"
 license=('MIT')
-provides=($_pkgname)
-conflicts=($_pkgname)
-depends=('bash')
 optdepends=(
   'feh: Wallpaper Display'
   'imagemagick: Image cropping / Thumbnail creation / Take a screenshot'
@@ -26,17 +23,11 @@ optdepends=(
   'xorg-xrandr: Resolution detection (Multi Monitor + Refresh rates)'
   'xorg-xwininfo: See https://github.com/dylanaraps/neofetch/wiki/Images-in-the-terminal'
 )
-makedepends=('git')
-source=("$pkgname::git+https://github.com/dylanaraps/neofetch.git")
-md5sums=('SKIP')
-
-pkgver() {
-  cd $pkgname
-  git describe --tags --long | sed -r -e 's,^[^0-9]*,,;s,([^-]*-g),r\1,;s,[-_],.,g'
-}
+source=("${pkgname}-${pkgver}::${url}/archive/${pkgver}.tar.gz")
+sha256sums=('05b61a8710e5c14b23dfb4299c69582b234563ccdfd7f54982af44fdfc2216e5')
 
 package() {
-  cd $pkgname
-  make DESTDIR="$pkgdir" install
-  install -D -m644 LICENSE.md "$pkgdir/usr/share/licenses/neofetch/LICENSE.md"
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    make DESTDIR="${pkgdir}" install
+    install -Dm 644 LICENSE.md "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.md"
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # neofetch
 
-Neofetch package pulled from git until Arch finally rebuilds (last repackaged `2020-10-02 15:11 UTC` as of 2022-01-25)
+Neofetch package pulled from the git commit that included the Crystal Linux logo until they [finally make a new release](https://github.com/dylanaraps/neofetch/releases/latest) (lastest release is from `2020-08-02` as of 2022-10-14).


### PR DESCRIPTION
Hi,

As stated yesterday, here's a rework of this repo:

**README:**
 - I modified the README according to the fact that the problem is not on Arch side but on Neofetch side itself. Indeed, Arch packaged [the latest available version/release](https://github.com/dylanaraps/neofetch/releases/latest) of Neofetch to this day. 
 Since packages on the official Arch repositories are not allowed to be VCS packages (for obvious stability reasons), the current `neofetch` package offered by Arch cannot be flagged as "out of date" because that's technically/factually not true.
The problem is *just* that the Neofetch maintainer never made a single release since `2020-08-02`, therefore since they added the Crystal logo in Neofetch.

**PKGBUILD:**
- Switched all vars to `${var}` format.
- Deleted the `_pkgname` var. Since it referred to the same value as the `pkgname` var, we don't need them both. Modified the rest of the PKGBUILD accordingly.
- Switched the `pkgver` var value to the commit hash that introduced the rebrand of `CrystalUX` to `Crystal Linux` in `neofetch`.  This hash will be taken as an higher value than the current `7.1.0-2` version offered by Arch so we don't have to worry about having an higher `pkgver/pkgrel` than Arch anymore. Therefore, I lowered the `pkgrel` to 1 as if it was a simple version bump.
- Deleted the `provides` and `conflicts` arrays. Indeed, every packages provide and conflict their `pkgname` implicitly (see: https://wiki.archlinux.org/title/PKGBUILD#provides and https://wiki.archlinux.org/title/PKGBUILD#conflicts), so we don't have to list them. Installing this package over the *regular* `neofetch` package will just be treated as an update. Reinstalling the regular `neofetch` package over this one will be treated as a downgrade.
- Deleted the `depends` array that contained `bash`. Indeed, `bash` is a member of the [base group package](https://archlinux.org/packages/core/any/base/), therefore it doesn't have to be listed explicitly.
- Switched source from "`git` cloning the repo from the last commit" to relying on the archive that points to the commit hash included in the `pkgver` value, so this package does not *really* act as a VCS package anymore (which we agreed to avoid). I added the integrity check of the archive accordingly. 
- Deleted the `git` makedepends since it is not needed anymore (see the previous point).
- Deleted the `pkgver ()` function since we don't want this package to act as a VCS package anymore.
- Various little style changes in the `package ()` function.

